### PR TITLE
fix period display

### DIFF
--- a/lib/models/showtimes.dart
+++ b/lib/models/showtimes.dart
@@ -11,6 +11,12 @@ class MoviesShowTimes {
   final List<MovieShowTimes> moviesShowTimes;
   final DateTime fetchedFrom;
   final DateTime fetchedTo;
+
+  String get periodDisplay {
+    var fetchedTo = this.fetchedTo;
+    if(fetchedTo == fetchedTo.toDate) fetchedTo = fetchedTo.subtract(const Duration(minutes: 5));
+    return 'Entre le ${fetchedFrom.day} et le ${fetchedTo.day}';
+  }
 }
 
 class MovieShowTimes with Comparable<MovieShowTimes> {

--- a/lib/pages/movies_page.dart
+++ b/lib/pages/movies_page.dart
@@ -66,7 +66,7 @@ class _MoviesPageState extends State<MoviesPage> with BlocProvider<MoviesPage, M
                               // Period
                               AppResources.spacerTiny,
                               Text(
-                                'Entre le ${moviesShowtimesData.fetchedFrom.day} et le ${moviesShowtimesData.fetchedTo.day}',
+                                moviesShowtimesData.periodDisplay,
                                 style: Theme.of(context).textTheme.caption?.copyWith(color: AppResources.colorDarkGrey),
                               ),
                             ],

--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -120,8 +120,8 @@ class ApiClient {
 
   Future<MoviesShowTimes> getMoviesList(List<Theater> theaters, { bool useCache = true }) async {
     // Prepare period
-    final from = mockedNow;
-    final to = mockedNow.add(Duration(days: 8));
+    final from = mockedNow.toDate;    // Truncate date to midnight, so it match request date (that is truncated).
+    final to = from.add(const Duration(days: 8));
 
     // Build movieShowTimes list
     final moviesShowTimesMap = Map<Movie, MovieShowTimes>();


### PR DESCRIPTION
Before, it displayed `de <from> à <to>` where `to` was excluded.
So now `to` is included.